### PR TITLE
feat: finalize manifest-driven gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ Galleri-billeder er lagret i `docs/assets/images/` og følger navnekonvention:
 - `gallery_large_{NNN}_{slug}.webp` — stor version (lightbox) ~1600px
 - `gallery_thumb_{NNN}_{slug}.webp` — thumbnail til grid ~800px
 
-Manifest: `docs/assets/images/gallery.json` indeholder poster med captions på alle sprog.  
+Manifest: `docs/assets/images/gallery.json` indeholder poster med captions på alle sprog.
 Sitet indlæser manifest via `docs/assets/js/gallery.js` og bygger et responsivt grid og lightbox automatisk.
 
 Upload flow:
 1. Opret `gallery_thumb_###_slug.webp` og `gallery_large_###_slug.webp`
 2. Tilføj en entry i `gallery.json` (id, slug, thumb, large, caption{da,en,de}, credit, year, tags)
 3. Commit og push — GitHub Pages opdaterer sitet.
+
+Script paths:
+- Sprog sider (`docs/da/`, `docs/en/`, `docs/de/`) bruger: `<script src="../assets/js/gallery.js"></script>`
+- Root `docs/index.html` bruger: `<script src="./assets/js/gallery.js"></script>`
 
 ## Tema og design
 

--- a/docs/assets/js/gallery.js
+++ b/docs/assets/js/gallery.js
@@ -1,6 +1,4 @@
-/* docs/assets/js/gallery.js
-   Dynamisk gallery renderer — henter docs/assets/images/gallery.json
-*/
+// docs/assets/js/gallery.js
 (async () => {
   const candidatePaths = [
     './assets/images/gallery.json',
@@ -8,70 +6,40 @@
     '/Florel/docs/assets/images/gallery.json',
     '/docs/assets/images/gallery.json'
   ];
-
-  let manifest = null;
-  let usedPath = null;
-  for (const p of candidatePaths) {
+  let manifest=null, usedPath=null;
+  for(const p of candidatePaths) {
     try {
-      const res = await fetch(p, {cache: 'no-cache'});
-      if (res.ok) {
-        manifest = await res.json();
-        usedPath = p.slice(0, p.lastIndexOf('/') + 1);
-        break;
-      }
-    } catch (err) { /* ignore */ }
+      const res = await fetch(p, {cache:'no-cache'});
+      if(res.ok) { manifest = await res.json(); usedPath = p.slice(0, p.lastIndexOf('/')+1); break; }
+    } catch(e) {}
   }
-  if (!manifest) { console.warn('Gallery: manifest not found at candidate paths'); return; }
+  if(!manifest){ console.warn('Gallery: manifest not found'); return; }
 
   let grid = document.getElementById('galleryGrid');
-  if (!grid) {
+  if(!grid){
     const sec = document.createElement('section');
-    sec.id = 'galleri';
-    sec.className = 'section container';
+    sec.id='galleri'; sec.className='section container';
     sec.innerHTML = '<h2>Galleri</h2><div id="galleryGrid" class="gallery"></div>';
-    const main = document.querySelector('main') || document.body;
-    const activities = document.querySelector('#activities,#aktivitaeten');
-    main.insertBefore(sec, activities);
+    (document.querySelector('main') || document.body).appendChild(sec);
     grid = document.getElementById('galleryGrid');
   }
-
   const lang = (document.documentElement.lang || 'en').substring(0,2);
-
   manifest.forEach(item => {
-    const img = document.createElement('img');
-    img.loading = 'lazy';
-    img.src = (usedPath + item.thumb).replace(/\/\.\//g,'/');
-    img.dataset.full = (usedPath + item.large).replace(/\/\.\//g,'/');
-    img.alt = (item.caption && (item.caption[lang] || item.caption.en)) || item.slug || '';
-    img.dataset.caption = item.caption ? (item.caption[lang] || item.caption.en || '') : '';
-    img.className = 'gallery-thumb';
+    const img=document.createElement('img');
+    img.loading='lazy';
+    img.src=(usedPath+item.thumb).replace(/\/\.\//g,'/');
+    img.dataset.full=(usedPath+item.large).replace(/\/\.\//g,'/');
+    img.alt=(item.caption && (item.caption[lang]||item.caption.en)) || item.slug || '';
+    img.dataset.caption = item.caption ? (item.caption[lang]||item.caption.en||'') : '';
+    img.className='gallery-thumb';
     grid.appendChild(img);
   });
 
-  // Lightbox
-  const lightbox = document.createElement('div');
-  lightbox.id = 'galleryLightbox';
-  Object.assign(lightbox.style, { display:'none', position:'fixed', inset:'0', background:'rgba(0,0,0,0.86)', alignItems:'center', justifyContent:'center', zIndex:9999, padding:'2rem' });
+  const lightbox=document.createElement('div'); lightbox.id='galleryLightbox';
+  Object.assign(lightbox.style,{display:'none',position:'fixed',inset:'0',background:'rgba(0,0,0,0.86)',alignItems:'center',justifyContent:'center',zIndex:9999,padding:'2rem'});
+  const lbImg=document.createElement('img'); const lbCap=document.createElement('div'); lbCap.className='lb-caption';
+  lightbox.appendChild(lbImg); lightbox.appendChild(lbCap); document.body.appendChild(lightbox);
 
-  const lbImg = document.createElement('img');
-  const lbCap = document.createElement('div');
-  lbCap.className = 'lb-caption';
-  lightbox.appendChild(lbImg);
-  lightbox.appendChild(lbCap);
-  document.body.appendChild(lightbox);
-
-  grid.addEventListener('click', (e) => {
-    if (e.target && e.target.tagName === 'IMG') {
-      lbImg.src = e.target.dataset.full || e.target.src;
-      lbCap.textContent = e.target.dataset.caption || '';
-      lightbox.style.display = 'flex';
-      document.body.style.overflow = 'hidden';
-    }
-  });
-  lightbox.addEventListener('click', (ev) => {
-    if (ev.target === lightbox) {
-      lightbox.style.display = 'none';
-      document.body.style.overflow = '';
-    }
-  });
+  grid.addEventListener('click', (e)=>{ if(e.target && e.target.tagName==='IMG'){ lbImg.src=e.target.dataset.full||e.target.src; lbCap.textContent=e.target.dataset.caption||''; lightbox.style.display='flex'; document.body.style.overflow='hidden'; }});
+  lightbox.addEventListener('click', ev => { if(ev.target===lightbox){ lightbox.style.display='none'; document.body.style.overflow=''; }});
 })();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -103,52 +103,8 @@ body{
   box-shadow: 0 14px 30px rgba(8,12,8,0.12);
 }
 
-/* Lightbox fallback style for the injected LB container */
-#galleryLightbox {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.86);
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  padding: 2rem;
-}
-#galleryLightbox img { max-width: 92%; max-height: 84%; border-radius: 8px; }
-#galleryLightbox .lb-caption { color: #fff; margin-top: 0.6rem; text-align:center; font-size: .95rem; }
+/* Lightbox fallback style */
+#galleryLightbox { display:none; position:fixed; inset:0; background:rgba(0,0,0,0.86); align-items:center; justify-content:center; z-index:9999; padding:2rem; }
+#galleryLightbox img { max-width:92%; max-height:84%; border-radius:8px; }
+#galleryLightbox .lb-caption { color:#fff; margin-top:0.6rem; text-align:center; font-size:.95rem; }
 
-/* ===== Gallery styles (appended) ===== */
-.gallery {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-.gallery img {
-  width: 100%;
-  height: auto;
-  display: block;
-  border-radius: 8px;
-  box-shadow: 0 6px 18px rgba(16,24,20,0.06);
-  transition: transform 0.28s cubic-bezier(.2,.8,.2,1), box-shadow 0.28s;
-  cursor: pointer;
-  object-fit: cover;
-}
-.gallery img:hover {
-  transform: translateY(-6px) scale(1.03);
-  box-shadow: 0 14px 30px rgba(8,12,8,0.12);
-}
-
-/* Lightbox fallback style for the injected LB container */
-#galleryLightbox {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.86);
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  padding: 2rem;
-}
-#galleryLightbox img { max-width: 92%; max-height: 84%; border-radius: 8px; }
-#galleryLightbox .lb-caption { color: #fff; margin-top: 0.6rem; text-align:center; font-size: .95rem; }


### PR DESCRIPTION
## Summary
- dedupe and append gallery styles
- replace gallery renderer with manifest-based script
- document gallery script paths

## Testing
- `curl -s https://raw.githubusercontent.com/PlatzDK/Florel/main/docs/assets/images/gallery.json | jq . >/dev/null && echo "gallery.json OK"`
- `python3 - <<'PY' ...`
- `npm test` *(fails: Missing script 'test')*
- `npm run build`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a45f95b8cc833086ea49af8c3b8e98