### PR TITLE
feat: mailto prefill and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Upload flow:
 2. Tilføj en entry i `gallery.json` (id, slug, thumb, large, caption{da,en,de}, credit, year, tags)
 3. Commit og push — GitHub Pages opdaterer sitet.
 
+### Mailto fallback / prefill
+
+Vi tilbyder en "Send os e-mail" fallback hvor brugeren kan udfylde en lille prefill-form og åbne deres mailklient med et struktureret template. Koden ligger i:
+
+- JS: `docs/assets/js/mailto.js` (recipient er obfuscated i JS).
+- UI: prefill forms i `docs/da/index.html`, `docs/en/index.html`, `docs/de/index.html`.
+- CSS: appended i `docs/assets/style.css`.
+
+For at ændre modtager: rediger `recipientUser` og `recipientDomain` i `docs/assets/js/mailto.js`.  
+Test: åbn en sprogside, udfyld felter og tryk "Åbn i mailapp" — din mailklient skal åbne med forudfyldt emne + body.
+
 Script paths:
 - Sprog sider (`docs/da/`, `docs/en/`, `docs/de/`) bruger: `<script src="../assets/js/gallery.js"></script>`
 - Root `docs/index.html` bruger: `<script src="./assets/js/gallery.js"></script>`

--- a/docs/assets/js/mailto.js
+++ b/docs/assets/js/mailto.js
@@ -1,0 +1,98 @@
+// docs/assets/js/mailto.js
+// Prefill + mailto builder with obfuscated recipient, multi-language templates and GA event.
+//
+// USAGE:
+// - Include <script src="../assets/js/mailto.js"></script> before </body> for pages in docs/<lang>/.
+// - Use HTML blocks (see tasks) for the UI placement.
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Configure recipient parts here (no cleartext email in HTML)
+  const recipientUser = 'info';
+  const recipientDomain = 'florelfiskeri.dk';
+  const recipient = recipientUser + '@' + recipientDomain;
+
+  // Templates per language (subject + intro)
+  const templates = {
+    da: {
+      subject: 'Reservationsforespørgsel - Florel',
+      intro: 'Hej,%0D%0AJeg%20vil%20gerne%20foresp%C3%B8rge%20om%20reservation%20af%20sommerhuset.%0D%0A%0D%0A'
+    },
+    en: {
+      subject: 'Reservation request - Florel',
+      intro: 'Hello,%0D%0AI%20would%20like%20to%20inquire%20about%20booking%20the%20cabin.%0D%0A%0D%0A'
+    },
+    de: {
+      subject: 'Buchungsanfrage - Florel',
+      intro: 'Guten%20Tag,%0D%0AIch%20moechte%20eine%20Anfrage%20zur%20Buchung%20des%20Ferienhauses%20stellen.%0D%0A%0D%0A'
+    }
+  };
+
+  const lang = (document.documentElement.lang || 'en').substring(0,2);
+  const tpl = templates[lang] || templates.en;
+
+  // Helper: build structured body and open mail client
+  function openMailFromFields(fields) {
+    // minimal validation
+    if (!fields.name || !fields.email || !fields.consent) {
+      return { ok: false, message: 'Udfyld venligst navn, email og accept.' };
+    }
+
+    // build body lines (use encodeURIComponent per value)
+    const enc = (s) => encodeURIComponent(String(s || '')).replace(/%20/g, '+');
+    let body = tpl.intro;
+    body += 'Navn: ' + enc(fields.name) + '%0D%0A';
+    body += 'Email: ' + enc(fields.email) + '%0D%0A';
+    if (fields.phone) body += 'Telefon: ' + enc(fields.phone) + '%0D%0A';
+    if (fields.arrival) body += 'Ankomst: ' + enc(fields.arrival) + '%0D%0A';
+    if (fields.departure) body += 'Afrejse: ' + enc(fields.departure) + '%0D%0A';
+    if (fields.guests) body += 'Gæster: ' + enc(fields.guests) + '%0D%0A';
+    if (fields.message) body += '%0D%0A' + enc(fields.message) + '%0D%0A';
+    body += '%0D%0A---%0D%0AJeg+accepterer+at+mine+oplysninger+behandles+af+Florel.';
+
+    const subject = encodeURIComponent(tpl.subject);
+    const mailto = `mailto:${recipient}?subject=${subject}&body=${body}`;
+
+    // analytics: try send gtag event if available
+    try { if (typeof gtag === 'function') gtag('event', 'mailto_initiated', { method: 'prefill', lang }); } catch(e){}
+
+    // open mail client
+    window.location.href = mailto;
+    return { ok: true, message: 'Opening mail client' };
+  }
+
+  // Attach handlers for any .mailto-prefill forms on the page
+  document.querySelectorAll('.mailto-prefill-form').forEach(form => {
+    form.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      const fields = {
+        name: form.querySelector('[name="mt_name"]')?.value || '',
+        email: form.querySelector('[name="mt_email"]')?.value || '',
+        phone: form.querySelector('[name="mt_phone"]')?.value || '',
+        arrival: form.querySelector('[name="mt_arrival"]')?.value || '',
+        departure: form.querySelector('[name="mt_departure"]')?.value || '',
+        guests: form.querySelector('[name="mt_guests"]')?.value || '',
+        message: form.querySelector('[name="mt_message"]')?.value || '',
+        consent: form.querySelector('[name="mt_consent"]')?.checked || false
+      };
+      const res = openMailFromFields(fields);
+      const status = form.querySelector('.mt-status');
+      if (status) status.textContent = res.message;
+    });
+  });
+
+  // Attach handlers for any simple mailto direct links (.mailto-direct)
+  document.querySelectorAll('.mailto-direct').forEach(a => {
+    a.addEventListener('click', (e) => {
+      // send analytics
+      try { if (typeof gtag === 'function') gtag('event', 'mailto_clicked', { method: 'direct', lang }); } catch(e){}
+      // recipient still constructed in JS: replace placeholder href if any
+      if (a.dataset.recipient === 'obfuscated') {
+        e.preventDefault();
+        a.href = 'mailto:' + recipient + (a.dataset.subject ? '?subject=' + encodeURIComponent(a.dataset.subject) : '');
+        window.location.href = a.href;
+      }
+    });
+  });
+
+});
+

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -108,3 +108,10 @@ body{
 #galleryLightbox img { max-width:92%; max-height:84%; border-radius:8px; }
 #galleryLightbox .lb-caption { color:#fff; margin-top:0.6rem; text-align:center; font-size:.95rem; }
 
+/* ===== Mailto prefill styles (appended) ===== */
+.mailto-form { background: rgba(255,255,255,0.02); padding: 1rem; border-radius: 8px; max-width: 560px; }
+.mailto-form h3 { margin-top: 0; }
+.mailto-form label { display:block; margin-bottom:0.5rem; font-size:0.95rem; }
+.mailto-form input, .mailto-form textarea { width:100%; padding:0.5rem; border-radius:6px; border:1px solid rgba(0,0,0,0.08); margin-top:0.25rem; box-sizing:border-box; }
+.mailto-form .btn { display:inline-block; margin-top:0.5rem; }
+a.mailto-direct { color: inherit; text-decoration: underline; }

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -71,12 +71,28 @@
       <h2>Reservér dit ophold</h2>
       <p>Vil I kombinere afslapning og fiskeri? Book opholdet her — og husk: til ferskvands- og særlige å-stræk kræves ofte både statsligt fisketegn og lokalt dagkort.</p>
       <p><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Send reservationsforespørgsel</a></p>
+      <!-- Prefill mailto form (Danish) -->
+      <form class="mailto-prefill-form mailto-form" aria-label="Reservation via email">
+        <h3>Send os en e-mail i stedet</h3>
+        <label>Navn* <input name="mt_name" type="text" required></label>
+        <label>Email* <input name="mt_email" type="email" required></label>
+        <label>Telefon <input name="mt_phone" type="tel"></label>
+        <label>Ankomst <input name="mt_arrival" type="date"></label>
+        <label>Afrejse <input name="mt_departure" type="date"></label>
+        <label>Antal gæster <input name="mt_guests" type="number" min="1" max="50"></label>
+        <label>Ønsker <textarea name="mt_message" rows="3"></textarea></label>
+        <label><input name="mt_consent" type="checkbox" required> Jeg accepterer at mine oplysninger behandles.</label>
+        <p><button class="btn" type="submit">Åbn i mailapp</button></p>
+        <p class="mt-status" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 
   <footer class="site-footer container">
     <p>© Florel Fiskeri</p>
+    <p><a class="mailto-direct" data-recipient="obfuscated" data-subject="Reservationsforesp%C3%B8rgsel%20-%20Florel" href="#">Kontakt via e-mail</a></p>
   </footer>
   <script src="../assets/js/gallery.js"></script>
+  <script src="../assets/js/mailto.js"></script>
 </body>
 </html>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -70,12 +70,28 @@
       <h2>Buchen</h2>
       <p>Möchten Sie Ruhe in der Natur und erstklassiges Angeln? Buchen Sie hier — beachten Sie: Für viele Süßwassergewässer und Flussabschnitte benötigen Sie einen staatlichen Angelschein und lokale Tageskarten.</p>
       <p><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Anfrage senden</a></p>
+      <!-- Prefill mailto form (German) -->
+      <form class="mailto-prefill-form mailto-form" aria-label="Reservierung per E-Mail">
+        <h3>Senden Sie uns stattdessen eine E-Mail</h3>
+        <label>Name* <input name="mt_name" type="text" required></label>
+        <label>E-Mail* <input name="mt_email" type="email" required></label>
+        <label>Telefon <input name="mt_phone" type="tel"></label>
+        <label>Anreise <input name="mt_arrival" type="date"></label>
+        <label>Abreise <input name="mt_departure" type="date"></label>
+        <label>Gäste <input name="mt_guests" type="number" min="1" max="50"></label>
+        <label>Nachricht <textarea name="mt_message" rows="3"></textarea></label>
+        <label><input name="mt_consent" type="checkbox" required> Ich bin mit der Verarbeitung meiner Daten einverstanden.</label>
+        <p><button class="btn" type="submit">In Mail-App öffnen</button></p>
+        <p class="mt-status" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 
   <footer class="site-footer container">
     <p>© Florel</p>
+    <p><a class="mailto-direct" data-recipient="obfuscated" data-subject="Buchungsanfrage%20-%20Florel" href="#">Kontakt via E-Mail</a></p>
   </footer>
 <script src="../assets/js/gallery.js"></script>
+<script src="../assets/js/mailto.js"></script>
 </body>
 </html>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -70,12 +70,28 @@
       <h2>Ready to book?</h2>
       <p>Want restful nature and great fishing? Book your stay here — note: for many freshwater waters and some river stretches you need both the national fishing license and local day permits.</p>
       <p><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Send reservation enquiry</a></p>
+      <!-- Prefill mailto form (English) -->
+      <form class="mailto-prefill-form mailto-form" aria-label="Reservation via email">
+        <h3>Send us an email instead</h3>
+        <label>Name* <input name="mt_name" type="text" required></label>
+        <label>Email* <input name="mt_email" type="email" required></label>
+        <label>Phone <input name="mt_phone" type="tel"></label>
+        <label>Arrival <input name="mt_arrival" type="date"></label>
+        <label>Departure <input name="mt_departure" type="date"></label>
+        <label>Guests <input name="mt_guests" type="number" min="1" max="50"></label>
+        <label>Message <textarea name="mt_message" rows="3"></textarea></label>
+        <label><input name="mt_consent" type="checkbox" required> I agree that my data is processed.</label>
+        <p><button class="btn" type="submit">Open in mail app</button></p>
+        <p class="mt-status" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 
   <footer class="site-footer container">
     <p>© Florel Fishing</p>
+    <p><a class="mailto-direct" data-recipient="obfuscated" data-subject="Reservation%20request%20-%20Florel" href="#">Contact via email</a></p>
   </footer>
 <script src="../assets/js/gallery.js"></script>
+<script src="../assets/js/mailto.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS helper for mailto prefill with obfuscated recipient and analytics
- embed small prefill forms on DA/EN/DE pages and add obfuscated footer link
- document mailto prefill fallback in README

## Testing
- `test -f docs/assets/js/mailto.js && echo "OK: mailto.js exists" || echo "MISSING: mailto.js"`
- `grep -n "Mailto prefill styles" docs/assets/style.css || echo "CSS not appended"`
- `grep -n "Mailto fallback" README.md`
- `npm run build`

README read: docs root = docs/, images path = docs/assets/images/, gallery manifest naming respected.


------
https://chatgpt.com/codex/tasks/task_e_68a82db054b08330afa171064b466f5f