### PR TITLE
Handle phone number validation edge cases

### DIFF
--- a/docs/assets/js/mailto.js
+++ b/docs/assets/js/mailto.js
@@ -71,6 +71,13 @@ document.addEventListener('DOMContentLoaded', () => {
       if (cc && cc.startsWith('+') && !val.startsWith('+')) {
         full = cc + val.replace(/^\+/, '');
       }
+      if (/[a-zA-Z]/.test(full)) {
+        phoneError.textContent = msgs.invalidPhone;
+        phoneError.style.display = 'block';
+        submitBtn.disabled = true;
+        submitBtn.style.opacity = 0.5;
+        return;
+      }
       const norm = normalizePhone(full);
       if (!norm) {
         phoneError.style.display = 'none';
@@ -79,8 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       if (!isValidPhoneNumber(norm)) {
-        phoneError.textContent = msgs.invalidPhone;
-        phoneError.style.display = 'block';
+        phoneError.style.display = 'none';
         submitBtn.disabled = true;
         submitBtn.style.opacity = 0.5;
       } else {


### PR DESCRIPTION
## Summary
- ensure phone field errors if letters are entered
- hide phone error for numeric input that fails length rules while leaving submit disabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d15ea0708330804ec694938ec51b