### PR TITLE
feat: quick UI wins — vars, container, hero + CTA

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,3 +1,46 @@
+/* ===== THEME VARIABLES & LAYOUT (Quick-wins) ===== */
+:root{
+  --primary-forest: #2f4f37;
+  --muted: #556a58;
+  --accent: #c99c19;
+  --bg: #f5f7f4;
+  --content-max-width: 1100px;
+  --side-padding: 1rem;
+}
+
+/* Global page bg */
+body { background-color: var(--bg); color: #173025; }
+
+/* Container for readable line-length and centered content */
+.container {
+  max-width: var(--content-max-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--side-padding);
+  padding-right: var(--side-padding);
+  box-sizing: border-box;
+}
+
+/* Section spacing */
+.section { padding-top: 3rem; padding-bottom: 3rem; }
+
+/* Paragraph readability */
+p { line-height: 1.6; max-width: 70ch; margin-left: auto; margin-right: auto; }
+
+/* CTA primary style (used for hero) */
+.btn-primary {
+  background: var(--accent);
+  color: #071b11;
+  padding: 0.9rem 1.25rem;
+  border-radius: 10px;
+  font-weight: 700;
+  display: inline-block;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.08);
+}
+.btn-primary:focus { outline: 3px solid rgba(47,79,55,0.14); outline-offset: 3px; }
+
 /* docs/assets/style.css
    Forest theme overrides for Florel
    - Uses external hero image so you don't need to upload a local file.

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -11,8 +11,9 @@
   <link rel="alternate" hreflang="de" href="https://platzdk.github.io/Florel/de/">
   <link rel="alternate" hreflang="x-default" href="https://platzdk.github.io/Florel/">
   <link rel="stylesheet" href="../assets/style.css">
+  <link rel="preload" as="image" href="../assets/images/lake-sunset.jpg">
 </head>
-  
+
 <body>
   <header class="site-header">
     <div class="container">
@@ -23,14 +24,21 @@
     </div>
   </header>
 
-  <main class="site-main">
-    <section class="hero">
-      <div class="hero-inner container">
-        <h2>Florel Fiskeri</h2>
-        <p class="tagline">Sommerhus midt i skoven ved sø og å. Oplev afslappende naturoplevelser og fantastiske muligheder for lystfiskeri — fra put &amp; take og søfiskeri til kyst- og åfiskeri inden for kort rækkevidde.</p>
-        <p class="cta"><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Send reservationsforespørgsel</a></p>
+  <header class="hero" role="banner" aria-label="Florel hero">
+    <div class="hero-bg" style="background-image: linear-gradient(rgba(20,30,20,0.35), rgba(20,30,20,0.15)), url('../assets/images/lake-sunset.jpg');">
+      <div class="container" style="padding:6rem 0; text-align:center;">
+        <h1 style="font-size:2.1rem; color:#fff; margin:0 0 0.6rem; text-shadow: 0 4px 18px rgba(0,0,0,0.45);">
+          Florel Fiskeri
+        </h1>
+        <p class="lead" style="color: rgba(255,255,255,0.95); max-width: 60ch; margin:0 auto 1rem;">
+          Sommerhus i tæt skov med adgang til sø og å — det perfekte sted for familier og lystfiskere.
+        </p>
+        <a href="#reservation" class="btn-primary cta" aria-label="Reserver dit ophold">Reserver dit ophold</a>
       </div>
-    </section>
+    </div>
+  </header>
+
+  <main id="main-content" class="site-main">
 
     <section id="galleri" class="section">
       <div class="container">
@@ -75,7 +83,7 @@
       </div>
     </section>
 
-    <section class="section booking">
+    <section id="reservation" class="section booking">
       <div class="container">
         <h2>Reservér dit ophold</h2>
         <p>Vil I kombinere afslapning og fiskeri? Book opholdet her — og husk: til ferskvands- og særlige å-stræk kræves ofte både statsligt fisketegn og lokalt dagkort.</p>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -11,6 +11,7 @@
   <link rel="alternate" hreflang="de" href="https://platzdk.github.io/Florel/de/">
   <link rel="alternate" hreflang="x-default" href="https://platzdk.github.io/Florel/">
   <link rel="stylesheet" href="../assets/style.css">
+  <link rel="preload" as="image" href="../assets/images/lake-sunset.jpg">
 </head>
 <body>
   <header class="site-header">
@@ -22,14 +23,21 @@
     </div>
   </header>
 
-  <main class="site-main">
-    <section class="hero">
-      <div class="hero-inner container">
-        <h2>Florel Angler-Retreat</h2>
-        <p class="tagline">Ferienhaus mitten im Wald mit See- und Bachzugang. Genießen Sie Ruhe in der Natur und hervorragende Angelmöglichkeiten — Put &amp; Take, Seen sowie Fluss- und Küstenangeln alles in kurzer Entfernung.</p>
-        <p class="cta"><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Anfrage zur Reservierung senden</a></p>
+  <header class="hero" role="banner" aria-label="Florel hero">
+    <div class="hero-bg" style="background-image: linear-gradient(rgba(20,30,20,0.35), rgba(20,30,20,0.15)), url('../assets/images/lake-sunset.jpg');">
+      <div class="container" style="padding:6rem 0; text-align:center;">
+        <h1 style="font-size:2.1rem; color:#fff; margin:0 0 0.6rem; text-shadow: 0 4px 18px rgba(0,0,0,0.45);">
+          Florel Angeln
+        </h1>
+        <p class="lead" style="color: rgba(255,255,255,0.95); max-width: 60ch; margin:0 auto 1rem;">
+          Ferienhaus im dichten Wald mit Zugang zu See und Bach – der perfekte Ort für Familien und Angler.
+        </p>
+        <a href="#reservation" class="btn-primary cta" aria-label="Aufenthalt buchen">Aufenthalt buchen</a>
       </div>
-    </section>
+    </div>
+  </header>
+
+  <main id="main-content" class="site-main">
 
     <section id="galleri" class="section">
       <div class="container">
@@ -74,7 +82,7 @@
       </div>
     </section>
 
-    <section class="section booking">
+    <section id="reservation" class="section booking">
       <div class="container">
         <h2>Buchen</h2>
         <p>Möchten Sie Ruhe in der Natur und erstklassiges Angeln? Buchen Sie hier — beachten Sie: Für viele Süßwassergewässer und Flussabschnitte benötigen Sie einen staatlichen Angelschein und lokale Tageskarten.</p>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -11,6 +11,7 @@
   <link rel="alternate" hreflang="de" href="https://platzdk.github.io/Florel/de/">
   <link rel="alternate" hreflang="x-default" href="https://platzdk.github.io/Florel/">
   <link rel="stylesheet" href="../assets/style.css">
+  <link rel="preload" as="image" href="../assets/images/lake-sunset.jpg">
 </head>
 <body>
   <header class="site-header">
@@ -22,14 +23,21 @@
     </div>
   </header>
 
-  <main class="site-main">
-    <section class="hero">
-      <div class="hero-inner container">
-        <h2>Florel Fishing Retreat</h2>
-        <p class="tagline">Forest cabin by lake and stream. Enjoy peaceful nature and excellent fishing — from put &amp; take lakes and river fishing to coastal angling, all within easy reach.</p>
-        <p class="cta"><a class="btn btn-primary" href="mailto:info@florelfiskeri.dk">Send reservation enquiry</a></p>
+  <header class="hero" role="banner" aria-label="Florel hero">
+    <div class="hero-bg" style="background-image: linear-gradient(rgba(20,30,20,0.35), rgba(20,30,20,0.15)), url('../assets/images/lake-sunset.jpg');">
+      <div class="container" style="padding:6rem 0; text-align:center;">
+        <h1 style="font-size:2.1rem; color:#fff; margin:0 0 0.6rem; text-shadow: 0 4px 18px rgba(0,0,0,0.45);">
+          Florel Fishing Retreat
+        </h1>
+        <p class="lead" style="color: rgba(255,255,255,0.95); max-width: 60ch; margin:0 auto 1rem;">
+          Forest cabin in dense woods with access to lake and stream — the perfect place for families and anglers.
+        </p>
+        <a href="#reservation" class="btn-primary cta" aria-label="Book your stay">Book your stay</a>
       </div>
-    </section>
+    </div>
+  </header>
+
+  <main id="main-content" class="site-main">
 
     <section id="galleri" class="section">
       <div class="container">
@@ -74,7 +82,7 @@
       </div>
     </section>
 
-    <section class="section booking">
+    <section id="reservation" class="section booking">
       <div class="container">
         <h2>Ready to book?</h2>
         <p>Want restful nature and great fishing? Book your stay here — note: for many freshwater waters and some river stretches you need both the national fishing license and local day permits.</p>


### PR DESCRIPTION
README read: docs root = docs/, assets path = docs/assets/, applying UI quick-wins (vars/container/hero).

## Summary
- add theme variables, container layout and CTA styling
- implement hero cover with CTA for da/en/de
- preload hero image and wrap key sections in `.container`

## Testing
- `test -f docs/assets/style.css && echo "OK: style.css" || echo "MISSING: style.css"`
- `grep -n "THEME VARIABLES & LAYOUT" docs/assets/style.css || true`
- `grep -Rni "hero-bg" docs || true`
- `grep -n ":root{" docs/assets/style.css`
- `grep -Rni "<div class=\"container\"" docs | sed -n '1,200p'`
- `timeout 1 python3 -m http.server 8000`

PR MUST NOT BE MERGED without owner approval.

------
https://chatgpt.com/codex/tasks/task_e_68a8e6a9820483309d431fac439074f9