### PR TITLE
feat: move gallery under intro

### DIFF
--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -58,6 +58,14 @@
       </div>
     </section>
 
+
+    <section id="galleri" class="section">
+      <div class="container">
+        <h2>Galleri</h2>
+        <div id="galleryGrid" class="gallery"></div>
+      </div>
+    </section>
+
     <section id="local-fishing" class="section">
       <div class="container">
         <h2>Lokale fiskesteder</h2>
@@ -107,14 +115,6 @@
         <p>For fiskeri i søer og åer kræves statsligt fisketegn og ofte lokalt dagkort. Put &amp; take-søer kræver kun billet på stedet. Kystfiskeri kræver kun statsligt fisketegn – ellers er det frit at finde sin plads.</p>
       </div>
     </section>
-
-    <section id="galleri" class="section">
-      <div class="container">
-        <h2>Galleri</h2>
-        <div id="galleryGrid" class="gallery"></div>
-      </div>
-    </section>
-
     <section id="activities" class="section">
       <div class="container">
         <h2>Aktiviteter for lystfiskere</h2>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -57,6 +57,14 @@
       </div>
     </section>
 
+
+    <section id="galleri" class="section">
+      <div class="container">
+        <h2>Galleri</h2>
+        <div id="galleryGrid" class="gallery"></div>
+      </div>
+    </section>
+
     <!-- TODO: translate this Local fishing list to German -->
     <section id="local-fishing" class="section">
       <div class="container">
@@ -108,14 +116,6 @@
         <p>Für das Angeln in Seen und Flüssen ist eine staatliche Angellizenz und oft auch eine lokale Tageskarte erforderlich. Put &amp; Take-Seen benötigen nur ein Ticket vor Ort. Für das Küstenangeln ist lediglich die staatliche Angellizenz notwendig – ansonsten kann man frei von der Küste angeln.</p>
       </div>
     </section>
-
-    <section id="galleri" class="section">
-      <div class="container">
-        <h2>Galleri</h2>
-        <div id="galleryGrid" class="gallery"></div>
-      </div>
-    </section>
-
     <section id="aktivitaeten" class="section">
       <div class="container">
         <h2>Angelaktivitäten</h2>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -57,6 +57,14 @@
       </div>
     </section>
 
+
+    <section id="galleri" class="section">
+      <div class="container">
+        <h2>Galleri</h2>
+        <div id="galleryGrid" class="gallery"></div>
+      </div>
+    </section>
+
     <!-- TODO: translate this Local fishing list to English -->
     <section id="local-fishing" class="section">
       <div class="container">
@@ -108,14 +116,6 @@
         <p>For fishing in lakes and rivers, a state fishing license and often a local day ticket is required. Put &amp; take ponds only require a ticket bought on-site. Coastal fishing only requires a state fishing license – otherwise you can fish freely from the shore.</p>
       </div>
     </section>
-
-    <section id="galleri" class="section">
-      <div class="container">
-        <h2>Galleri</h2>
-        <div id="galleryGrid" class="gallery"></div>
-      </div>
-    </section>
-
     <section id="activities" class="section">
       <div class="container">
         <h2>Fishing activities</h2>


### PR DESCRIPTION
## Summary
- move gallery section directly after intro on Danish, English, and German pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a460f7788330b8403a74bbe34f70