### PR TITLE
docs: remove Intro headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dette repo indeholder en simpel statisk hjemmeside for Florel, et skovsommerhus 
 - **Dansk (`/da/`):** fuldt indhold om huset, aktiviteter, lokale fiskesteder, praktisk information, og booking. Indeholder canonical og hreflang-tags.
 - **English (`/en/`) og Deutsch (`/de/`):** tilsvarende sider med oversat indhold.
 - **Undersider med fiskesteder** (`/da/fiskeri.html`, `/en/fishing.html`, `/de/fischen.html`): lister de vigtigste søer, put & take-søer og floder med afstand.
-- Alle sprogforsider indeholder sektionerne Intro, lokale fiskesteder, fiskeri med/uden båd, guides & grejbutikker, klubber & konkurrencer, naturoplevelser og praktisk information.
+- Alle sprogforsider starter med en introduktion uden overskrift og indeholder sektionerne lokale fiskesteder, fiskeri med/uden båd, guides & grejbutikker, klubber & konkurrencer, naturoplevelser og praktisk information.
 
   ## Galleri
 

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -53,7 +53,6 @@
 
     <section id="intro" class="section">
       <div class="container">
-        <h2>Intro</h2>
         <p>Midtjylland er et sandt paradis for lystfiskere. Her finder du alt fra søfiskeri i Silkeborgsøerne, laksefiskeri i Karup Å til put &amp; take-søer og kystfiskeri i Limfjorden. Området omkring Engesvang byder på noget for både den erfarne lystfisker og familien, der vil prøve fiskelykken i smukke omgivelser.</p>
       </div>
     </section>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -52,7 +52,6 @@
 
     <section id="intro" class="section">
       <div class="container">
-        <h2>Intro</h2>
         <p>Mitteljütland ist ein wahres Paradies für Angler. Ob Seeangeln in den Silkeborg-Seen, Lachsangeln in der Karup Å, Put &amp; Take-Seen oder Küstenangeln am Limfjord – die Region um Engesvang bietet etwas für erfahrene Angler ebenso wie für Familien, die ihr Glück in der Natur versuchen möchten.</p>
       </div>
     </section>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -52,7 +52,6 @@
 
     <section id="intro" class="section">
       <div class="container">
-        <h2>Intro</h2>
         <p>Central Jutland is an angler’s paradise. From lake fishing in the Silkeborg Lakes, salmon fishing in Karup Å to put &amp; take ponds and coastal fishing in the Limfjord – the Engesvang area offers something for both experienced anglers and families who want to try their luck in beautiful surroundings.</p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove redundant "Intro" headings from Danish, English, and German docs
- document in README that intro sections start without a heading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5390d672c8330841052d149788610