### PR TITLE
Add About the house section to language pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dette repo indeholder en simpel statisk hjemmeside for Florel, et skovsommerhus 
 - **Root (`/`):** neutral landingsside med hero-sektion, kort tagline på tre sprog og knapper til at vælge Dansk/English/Deutsch. Indeholder hreflang links til alle sprogversioner.
 - **Dansk (`/da/`):** fuldt indhold om huset, aktiviteter, lokale fiskesteder, praktisk information, og booking. Indeholder canonical og hreflang-tags.
 - **English (`/en/`) og Deutsch (`/de/`):** tilsvarende sider med oversat indhold.
+- Hver sprogside indeholder også en sektion "Om huset" med lokaliseret beskrivelse af sommerhuset.
 - **Undersider med fiskesteder** (`/da/fiskeri.html`, `/en/fishing.html`, `/de/fischen.html`): lister de vigtigste søer, put & take-søer og floder med afstand.
 - Alle sprogforsider starter med en introduktion uden overskrift og indeholder sektionerne lokale fiskesteder, fiskeri med/uden båd, guides & grejbutikker, klubber & konkurrencer, naturoplevelser og praktisk information.
 

--- a/da/index.html
+++ b/da/index.html
@@ -15,6 +15,9 @@
         <a href="../en/index.html">English</a>
         <a href="../de/index.html">Deutsch</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">Om huset</a>
+      </nav>
     </div>
   </header>
 

--- a/da/index.html
+++ b/da/index.html
@@ -27,6 +27,11 @@
       </div>
     </section>
 
+    <section id="about-house" class="section container">
+      <h2>Om huset</h2>
+      <p>Det hyggelige træsommerhus har stue med brændeovn, fuldt udstyret køkken og to soverum med plads til fire gæster. Der er bad med varmt vand og en stor terrasse med udsigt til sø og skov.</p>
+    </section>
+
     <section id="aktiviteter" class="section container">
       <h2>Aktiviteter for lystfiskere</h2>
       <p>Danmark byder på alsidige fiskemuligheder: kyst- og havfiskeri, å- og søfiskeri samt put & take-søer.</p>

--- a/de/index.html
+++ b/de/index.html
@@ -15,6 +15,9 @@
         <a href="../da/index.html">Dansk</a>
         <a href="../en/index.html">English</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">Über das Haus</a>
+      </nav>
     </div>
   </header>
 

--- a/de/index.html
+++ b/de/index.html
@@ -27,6 +27,11 @@
       </div>
     </section>
 
+    <section id="about-house" class="section container">
+      <h2>Über das Haus</h2>
+      <p>Die gemütliche Holzhütte bietet ein Wohnzimmer mit Kaminofen, eine komplett ausgestattete Küche und zwei Schlafzimmer für vier Gäste. Das Bad verfügt über Warmwasserdusche und die große Terrasse blickt auf See und Wald.</p>
+    </section>
+
     <section id="aktivitaeten" class="section container">
       <h2>Angelaktivitäten</h2>
       <p>Dänemark bietet vielfältige Angelmöglichkeiten: Küsten- und Meeresangeln, Fluss- und Seenangeln sowie Put & Take-Gewässer.</p>

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -25,6 +25,7 @@
       </nav>
       <nav class="page-nav" aria-label="Sektion navigation">
         <a href="#intro">Intro</a>
+        <a href="#about-house">Om huset</a>
         <a href="#local-fishing">Lokale fiskesteder</a>
         <a href="#boat-fishing">Fiskeri med/uden båd</a>
         <a href="#guides">Guides &amp; grejbutikker</a>
@@ -54,6 +55,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Midtjylland er et sandt paradis for lystfiskere. Her finder du alt fra søfiskeri i Silkeborgsøerne, laksefiskeri i Karup Å til put &amp; take-søer og kystfiskeri i Limfjorden. Området omkring Engesvang byder på noget for både den erfarne lystfisker og familien, der vil prøve fiskelykken i smukke omgivelser.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>Om huset</h2>
+        <p>Det hyggelige træsommerhus byder på stue med brændeovn, et fuldt udstyret køkken og to soverum med i alt fire sovepladser. Badet har varmt vand, og den store træterrasse giver udsigt til søen og skoven.</p>
       </div>
     </section>
 

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -25,6 +25,7 @@
       </nav>
       <nav class="page-nav" aria-label="Sektion navigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Galleri</a>
         <a href="#about-house">Om huset</a>
         <a href="#local-fishing">Lokale fiskesteder</a>
         <a href="#boat-fishing">Fiskeri med/uden båd</a>
@@ -32,6 +33,7 @@
         <a href="#clubs">Klubber &amp; konkurrencer</a>
         <a href="#nature">Naturoplevelser</a>
         <a href="#practical">Praktisk information</a>
+        <a href="#reservation">Reservér ophold</a>
       </nav>
     </div>
   </header>

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -24,6 +24,7 @@
       </nav>
       <nav class="page-nav" aria-label="Bereichsnavigation">
         <a href="#intro">Intro</a>
+        <a href="#about-house">Über das Haus</a>
         <a href="#local-fishing">Lokale Angelplätze</a>
         <a href="#boat-fishing">Angeln mit/ohne Boot</a>
         <a href="#guides">Guides &amp; Angelgeschäfte</a>
@@ -53,6 +54,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Mitteljütland ist ein wahres Paradies für Angler. Ob Seeangeln in den Silkeborg-Seen, Lachsangeln in der Karup Å, Put &amp; Take-Seen oder Küstenangeln am Limfjord – die Region um Engesvang bietet etwas für erfahrene Angler ebenso wie für Familien, die ihr Glück in der Natur versuchen möchten.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>Über das Haus</h2>
+        <p>Die gemütliche Holzhütte verfügt über ein Wohnzimmer mit Kaminofen, eine voll ausgestattete Küche und zwei Schlafzimmer für insgesamt vier Gäste. Das Bad bietet warmes Wasser und die große Terrasse hat Blick auf See und Wald.</p>
       </div>
     </section>
 

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -24,6 +24,7 @@
       </nav>
       <nav class="page-nav" aria-label="Bereichsnavigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Galerie</a>
         <a href="#about-house">Über das Haus</a>
         <a href="#local-fishing">Lokale Angelplätze</a>
         <a href="#boat-fishing">Angeln mit/ohne Boot</a>
@@ -31,6 +32,7 @@
         <a href="#clubs">Vereine &amp; Wettbewerbe</a>
         <a href="#nature">Naturerlebnisse</a>
         <a href="#practical">Praktische Informationen</a>
+        <a href="#reservation">Buchen</a>
       </nav>
     </div>
   </header>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -24,6 +24,7 @@
       </nav>
       <nav class="page-nav" aria-label="Section navigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Gallery</a>
         <a href="#about-house">About the house</a>
         <a href="#local-fishing">Local fishing spots</a>
         <a href="#boat-fishing">Fishing with/without a boat</a>
@@ -31,6 +32,7 @@
         <a href="#clubs">Clubs &amp; competitions</a>
         <a href="#nature">Nature experiences</a>
         <a href="#practical">Practical information</a>
+        <a href="#reservation">Book your stay</a>
       </nav>
     </div>
   </header>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -24,6 +24,7 @@
       </nav>
       <nav class="page-nav" aria-label="Section navigation">
         <a href="#intro">Intro</a>
+        <a href="#about-house">About the house</a>
         <a href="#local-fishing">Local fishing spots</a>
         <a href="#boat-fishing">Fishing with/without a boat</a>
         <a href="#guides">Guides &amp; tackle shops</a>
@@ -53,6 +54,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Central Jutland is an angler’s paradise. From lake fishing in the Silkeborg Lakes, salmon fishing in Karup Å to put &amp; take ponds and coastal fishing in the Limfjord – the Engesvang area offers something for both experienced anglers and families who want to try their luck in beautiful surroundings.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>About the house</h2>
+        <p>The cosy wooden cabin offers a living room with wood stove, a fully equipped kitchen and two bedrooms accommodating four guests. The bathroom has a hot shower and the spacious deck looks over the lake and forest.</p>
       </div>
     </section>
 

--- a/en/index.html
+++ b/en/index.html
@@ -27,6 +27,11 @@
       </div>
     </section>
 
+    <section id="about-house" class="section container">
+      <h2>About the house</h2>
+      <p>The cosy wooden cabin includes a living room with wood stove, a fully equipped kitchen and two bedrooms sleeping four guests. The bathroom has hot water and the large terrace overlooks the lake and forest.</p>
+    </section>
+
     <section id="activities" class="section container">
       <h2>Fishing activities</h2>
       <p>Denmark offers varied angling: coastal and sea fishing, river and lake fishing, and put & take ponds.</p>

--- a/en/index.html
+++ b/en/index.html
@@ -15,6 +15,9 @@
         <a href="../da/index.html">Dansk</a>
         <a href="../de/index.html">Deutsch</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">About the house</a>
+      </nav>
     </div>
   </header>
 

--- a/tests/nav.test.js
+++ b/tests/nav.test.js
@@ -1,0 +1,17 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+
+const langs = ['da', 'en', 'de'];
+
+describe('page navigation', () => {
+  langs.forEach((lang) => {
+    it(`includes about-house link on ${lang} page`, () => {
+      const html = readFileSync(`docs/${lang}/index.html`, 'utf-8');
+      const dom = new JSDOM(html);
+      const link = dom.window.document.querySelector('nav.page-nav a[href="#about-house"]');
+      expect(link).not.toBeNull();
+    });
+  });
+});

--- a/tests/nav.test.js
+++ b/tests/nav.test.js
@@ -7,8 +7,14 @@ const langs = ['da', 'en', 'de'];
 
 describe('page navigation', () => {
   langs.forEach((lang) => {
-    it(`includes about-house link on ${lang} page`, () => {
+    it(`includes about-house link on docs/${lang} page`, () => {
       const html = readFileSync(`docs/${lang}/index.html`, 'utf-8');
+      const dom = new JSDOM(html);
+      const link = dom.window.document.querySelector('nav.page-nav a[href="#about-house"]');
+      expect(link).not.toBeNull();
+    });
+    it(`includes about-house link on ${lang} page`, () => {
+      const html = readFileSync(`${lang}/index.html`, 'utf-8');
       const dom = new JSDOM(html);
       const link = dom.window.document.querySelector('nav.page-nav a[href="#about-house"]');
       expect(link).not.toBeNull();


### PR DESCRIPTION
## Summary
- Add localized "About the house" section to Danish, English and German pages
- Link the new section from each page's navigation
- Test navigation includes the About section anchor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b56663adbc833092c7876b8556c9b3