### PR TITLE
Add about-house navigation links on language pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dette repo indeholder en simpel statisk hjemmeside for Florel, et skovsommerhus 
 - **Root (`/`):** neutral landingsside med hero-sektion, kort tagline på tre sprog og knapper til at vælge Dansk/English/Deutsch. Indeholder hreflang links til alle sprogversioner.
 - **Dansk (`/da/`):** fuldt indhold om huset, aktiviteter, lokale fiskesteder, praktisk information, og booking. Indeholder canonical og hreflang-tags.
 - **English (`/en/`) og Deutsch (`/de/`):** tilsvarende sider med oversat indhold.
+- Hver sprogside indeholder også en sektion "Om huset" med lokaliseret beskrivelse af sommerhuset.
 - **Undersider med fiskesteder** (`/da/fiskeri.html`, `/en/fishing.html`, `/de/fischen.html`): lister de vigtigste søer, put & take-søer og floder med afstand.
 - Alle sprogforsider starter med en introduktion uden overskrift og indeholder sektionerne lokale fiskesteder, fiskeri med/uden båd, guides & grejbutikker, klubber & konkurrencer, naturoplevelser og praktisk information.
 

--- a/da/index.html
+++ b/da/index.html
@@ -15,6 +15,9 @@
         <a href="../en/index.html">English</a>
         <a href="../de/index.html">Deutsch</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">Om huset</a>
+      </nav>
     </div>
   </header>
 
@@ -25,6 +28,11 @@
         <p class="tagline">Sommerhus midt i skoven ved sø og å. Oplev afslappende naturoplevelser og fantastiske muligheder for lystfiskeri — fra put & take og søfiskeri til kyst- og åfiskeri inden for kort rækkevidde.</p>
         <p class="cta"><a class="btn btn-primary" href="mailto:info@example.com">Send reservationsforespørgsel</a></p>
       </div>
+    </section>
+
+    <section id="about-house" class="section container">
+      <h2>Om huset</h2>
+      <p>Det hyggelige træsommerhus har stue med brændeovn, fuldt udstyret køkken og to soverum med plads til fire gæster. Der er bad med varmt vand og en stor terrasse med udsigt til sø og skov.</p>
     </section>
 
     <section id="aktiviteter" class="section container">

--- a/de/index.html
+++ b/de/index.html
@@ -15,6 +15,9 @@
         <a href="../da/index.html">Dansk</a>
         <a href="../en/index.html">English</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">Über das Haus</a>
+      </nav>
     </div>
   </header>
 
@@ -25,6 +28,11 @@
         <p class="tagline">Ferienhaus mitten im Wald mit See- und Bachzugang. Genießen Sie Ruhe in der Natur und hervorragende Angelmöglichkeiten — Put & Take, Seen und Fluss- sowie Küstenstellen sind in kurzer Entfernung.</p>
         <p class="cta"><a class="btn btn-primary" href="mailto:info@example.com">Anfrage zur Reservierung senden</a></p>
       </div>
+    </section>
+
+    <section id="about-house" class="section container">
+      <h2>Über das Haus</h2>
+      <p>Die gemütliche Holzhütte bietet ein Wohnzimmer mit Kaminofen, eine komplett ausgestattete Küche und zwei Schlafzimmer für vier Gäste. Das Bad verfügt über Warmwasserdusche und die große Terrasse blickt auf See und Wald.</p>
     </section>
 
     <section id="aktivitaeten" class="section container">

--- a/docs/assets/js/gallery.js
+++ b/docs/assets/js/gallery.js
@@ -53,12 +53,20 @@ if (!lightbox) {
   closeBtn.innerHTML = '&times;';
   lightbox.appendChild(closeBtn);
 
-  const imgWrap = document.createElement('div'); imgWrap.className = 'lb-imgwrap';
-  const lbImg = document.createElement('img'); lbImg.className = 'lb-img'; lbImg.alt = '';
+
+  // Image wrapper
+  const imgWrap = document.createElement('div');
+  imgWrap.className = 'lb-imgwrap';
+  // Large image
+  const lbImg = document.createElement('img');
+  lbImg.className = 'lb-img';
+  lbImg.alt = '';
   imgWrap.appendChild(lbImg);
-
-  const lbCap = document.createElement('div'); lbCap.className = 'lb-caption'; lbCap.textContent = '';
-
+  // Caption under image
+  const lbCap = document.createElement('div');
+  lbCap.className = 'lb-caption';
+  lbCap.textContent = '';
+  // Structure: wrap > imgWrap > img, wrap > lbCap
   wrap.appendChild(imgWrap);
   wrap.appendChild(lbCap);
   lightbox.appendChild(wrap);
@@ -68,10 +76,16 @@ if (!lightbox) {
     lbImg.src = src;
     lbImg.alt = altText || '';
     lbCap.textContent = captionText || '';
+    // Center image and caption always
+    imgWrap.style.display = 'flex';
+    imgWrap.style.alignItems = 'center';
+    imgWrap.style.justifyContent = 'center';
+    lbCap.style.textAlign = 'center';
     lightbox.style.display = 'flex';
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
-    wrap.setAttribute('tabindex', '-1'); wrap.focus();
+    wrap.setAttribute('tabindex', '-1');
+    wrap.focus();
   }
   function closeLightbox() {
     lbImg.src = '';

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -254,17 +254,40 @@ h1,h2,h3, .section h2 { color: var(--primary-forest) !important; }
 }
 #galleryLightbox .lb-imgwrap {
   width: 100%;
-  display:flex; align-items:center; justify-content:center;
-  overflow:hidden; border-radius:12px; background:rgba(0,0,0,0.05);
+  min-height: 40vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 12px;
+  background: rgba(0,0,0,0.05);
+  box-sizing: border-box;
 }
 #galleryLightbox img.lb-img {
-  max-width:100%; max-height:78vh; height:auto; display:block; border-radius:8px;
-  box-shadow:0 8px 28px rgba(0,0,0,0.6); object-fit:contain;
+  max-width: 98vw;
+  max-height: 70vh;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0,0,0,0.6);
+  object-fit: contain;
+  background: #fff;
 }
 #galleryLightbox .lb-caption {
-  width:100%; color:#fff; font-size:0.98rem;
-  background: rgba(0,0,0,0.45); padding:0.6rem 0.8rem; border-radius:8px;
-  text-align:left; box-sizing:border-box; max-height:12vh; overflow:auto;
+  width: 100%;
+  color: #fff;
+  font-size: 1.05rem;
+  background: rgba(0,0,0,0.55);
+  padding: 0.7rem 1rem 0.8rem 1rem;
+  border-radius: 8px;
+  text-align: center;
+  box-sizing: border-box;
+  max-width: 98vw;
+  margin: 0.5rem auto 0 auto;
+  max-height: 14vh;
+  overflow: auto;
+  word-break: break-word;
 }
 #galleryLightbox .lb-close {
   position:absolute; top:14px; right:14px;
@@ -272,10 +295,10 @@ h1,h2,h3, .section h2 { color: var(--primary-forest) !important; }
   width:40px; height:40px; font-size:20px; cursor:pointer; z-index:10001;
 }
 @media (max-width:620px) {
-  #galleryLightbox { padding:1rem; }
-  #galleryLightbox .lb-wrap { max-width:98%; max-height:98vh; }
-  #galleryLightbox img.lb-img { max-height:70vh; }
-  #galleryLightbox .lb-caption { font-size:0.95rem; max-height:18vh; padding:0.5rem; }
+  #galleryLightbox { padding: 0.5rem; }
+  #galleryLightbox .lb-wrap { max-width: 99vw; max-height: 99vh; }
+  #galleryLightbox img.lb-img { max-width: 98vw; max-height: 48vh; }
+  #galleryLightbox .lb-caption { font-size: 0.97rem; max-height: 22vh; padding: 0.5rem 0.5rem 0.7rem 0.5rem; }
 }
 
 /* ===== Mailto form — visual fixes ===== */

--- a/docs/da/index.html
+++ b/docs/da/index.html
@@ -25,12 +25,15 @@
       </nav>
       <nav class="page-nav" aria-label="Sektion navigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Galleri</a>
+        <a href="#about-house">Om huset</a>
         <a href="#local-fishing">Lokale fiskesteder</a>
         <a href="#boat-fishing">Fiskeri med/uden båd</a>
         <a href="#guides">Guides &amp; grejbutikker</a>
         <a href="#clubs">Klubber &amp; konkurrencer</a>
         <a href="#nature">Naturoplevelser</a>
         <a href="#practical">Praktisk information</a>
+        <a href="#reservation">Reservér ophold</a>
       </nav>
     </div>
   </header>
@@ -54,6 +57,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Midtjylland er et sandt paradis for lystfiskere. Her finder du alt fra søfiskeri i Silkeborgsøerne, laksefiskeri i Karup Å til put &amp; take-søer og kystfiskeri i Limfjorden. Området omkring Engesvang byder på noget for både den erfarne lystfisker og familien, der vil prøve fiskelykken i smukke omgivelser.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>Om huset</h2>
+        <p>Det hyggelige træsommerhus byder på stue med brændeovn, et fuldt udstyret køkken og to soverum med i alt fire sovepladser. Badet har varmt vand, og den store træterrasse giver udsigt til søen og skoven.</p>
       </div>
     </section>
 

--- a/docs/de/index.html
+++ b/docs/de/index.html
@@ -24,12 +24,15 @@
       </nav>
       <nav class="page-nav" aria-label="Bereichsnavigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Galerie</a>
+        <a href="#about-house">Über das Haus</a>
         <a href="#local-fishing">Lokale Angelplätze</a>
         <a href="#boat-fishing">Angeln mit/ohne Boot</a>
         <a href="#guides">Guides &amp; Angelgeschäfte</a>
         <a href="#clubs">Vereine &amp; Wettbewerbe</a>
         <a href="#nature">Naturerlebnisse</a>
         <a href="#practical">Praktische Informationen</a>
+        <a href="#reservation">Buchen</a>
       </nav>
     </div>
   </header>
@@ -53,6 +56,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Mitteljütland ist ein wahres Paradies für Angler. Ob Seeangeln in den Silkeborg-Seen, Lachsangeln in der Karup Å, Put &amp; Take-Seen oder Küstenangeln am Limfjord – die Region um Engesvang bietet etwas für erfahrene Angler ebenso wie für Familien, die ihr Glück in der Natur versuchen möchten.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>Über das Haus</h2>
+        <p>Die gemütliche Holzhütte verfügt über ein Wohnzimmer mit Kaminofen, eine voll ausgestattete Küche und zwei Schlafzimmer für insgesamt vier Gäste. Das Bad bietet warmes Wasser und die große Terrasse hat Blick auf See und Wald.</p>
       </div>
     </section>
 

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -24,12 +24,15 @@
       </nav>
       <nav class="page-nav" aria-label="Section navigation">
         <a href="#intro">Intro</a>
+        <a href="#galleri">Gallery</a>
+        <a href="#about-house">About the house</a>
         <a href="#local-fishing">Local fishing spots</a>
         <a href="#boat-fishing">Fishing with/without a boat</a>
         <a href="#guides">Guides &amp; tackle shops</a>
         <a href="#clubs">Clubs &amp; competitions</a>
         <a href="#nature">Nature experiences</a>
         <a href="#practical">Practical information</a>
+        <a href="#reservation">Book your stay</a>
       </nav>
     </div>
   </header>
@@ -53,6 +56,13 @@
     <section id="intro" class="section">
       <div class="container">
         <p>Central Jutland is an angler’s paradise. From lake fishing in the Silkeborg Lakes, salmon fishing in Karup Å to put &amp; take ponds and coastal fishing in the Limfjord – the Engesvang area offers something for both experienced anglers and families who want to try their luck in beautiful surroundings.</p>
+      </div>
+    </section>
+
+    <section id="about-house" class="section">
+      <div class="container">
+        <h2>About the house</h2>
+        <p>The cosy wooden cabin offers a living room with wood stove, a fully equipped kitchen and two bedrooms accommodating four guests. The bathroom has a hot shower and the spacious deck looks over the lake and forest.</p>
       </div>
     </section>
 

--- a/en/index.html
+++ b/en/index.html
@@ -15,6 +15,9 @@
         <a href="../da/index.html">Dansk</a>
         <a href="../de/index.html">Deutsch</a>
       </nav>
+      <nav class="page-nav" aria-label="Section navigation">
+        <a href="#about-house">About the house</a>
+      </nav>
     </div>
   </header>
 
@@ -25,6 +28,11 @@
         <p class="tagline">Forest cabin by lake and stream. Enjoy peaceful nature and excellent fishing — put & take lakes, rivers and coastal spots all within easy reach.</p>
         <p class="cta"><a class="btn btn-primary" href="mailto:info@example.com">Send reservation enquiry</a></p>
       </div>
+    </section>
+
+    <section id="about-house" class="section container">
+      <h2>About the house</h2>
+      <p>The cosy wooden cabin includes a living room with wood stove, a fully equipped kitchen and two bedrooms sleeping four guests. The bathroom has hot water and the large terrace overlooks the lake and forest.</p>
     </section>
 
     <section id="activities" class="section container">

--- a/find_bidi_chars.sh
+++ b/find_bidi_chars.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Script: find_bidi_chars.sh
+# Beskrivelse: Finder skjulte/bidi-tegn i alle tekstfiler i projektet
+
+# Liste over uønskede Unicode-tegn (hex-koder)
+# 200B: ZERO WIDTH SPACE
+# 200C: ZERO WIDTH NON-JOINER
+# 200D: ZERO WIDTH JOINER
+# 202A: LEFT-TO-RIGHT EMBEDDING
+# 202B: RIGHT-TO-LEFT EMBEDDING
+# 202D: LEFT-TO-RIGHT OVERRIDE
+# 202E: RIGHT-TO-LEFT OVERRIDE
+# 2066: LEFT-TO-RIGHT ISOLATE
+# 2067: RIGHT-TO-LEFT ISOLATE
+# 2068: FIRST STRONG ISOLATE
+# 2069: POP DIRECTIONAL ISOLATE
+# FEFF: BYTE ORDER MARK (BOM)
+
+# Hex-mønstre til grep (bruges med -P og -n)
+PATTERNS=(
+    $'\xE2\x80\x8B' # U+200B
+    $'\xE2\x80\x8C' # U+200C
+    $'\xE2\x80\x8D' # U+200D
+    $'\xE2\x80\xAA' # U+202A
+    $'\xE2\x80\xAB' # U+202B
+    $'\xE2\x80\xAD' # U+202D
+    $'\xE2\x80\xAE' # U+202E
+    $'\xE2\x81\xA6' # U+2066
+    $'\xE2\x81\xA7' # U+2067
+    $'\xE2\x81\xA8' # U+2068
+    $'\xE2\x81\xA9' # U+2069
+    $'\xEF\xBB\xBF' # U+FEFF
+)
+
+# Find alle tekstfiler (undgå binære filer og node_modules)
+find . -type f \
+    ! -path "*/node_modules/*" \
+    ! -path "*/.git/*" | while read -r file; do
+    for pat in "${PATTERNS[@]}"; do
+        grep -a -n -H "$pat" "$file" 2>/dev/null
+    done
+done
+
+# Forklaring:
+# -a: tvinger tekstsøgning (også i "binære" filer)
+# -n: viser linjenummer
+# -H: viser filnavn
+# Udskriver: filnavn:linjenummer:linjeindhold

--- a/tests/nav.test.js
+++ b/tests/nav.test.js
@@ -1,0 +1,23 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+
+const langs = ['da', 'en', 'de'];
+
+describe('page navigation', () => {
+  langs.forEach((lang) => {
+    it(`includes about-house link on docs/${lang} page`, () => {
+      const html = readFileSync(`docs/${lang}/index.html`, 'utf-8');
+      const dom = new JSDOM(html);
+      const link = dom.window.document.querySelector('nav.page-nav a[href="#about-house"]');
+      expect(link).not.toBeNull();
+    });
+    it(`includes about-house link on ${lang} page`, () => {
+      const html = readFileSync(`${lang}/index.html`, 'utf-8');
+      const dom = new JSDOM(html);
+      const link = dom.window.document.querySelector('nav.page-nav a[href="#about-house"]');
+      expect(link).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- link to the localized "About the house" section from Danish, English, and German main pages
- test that both docs and main pages expose an `about-house` nav link

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b56663adbc833092c7876b8556c9b3